### PR TITLE
Add AutoMessage protocol in replace of Sourcery annotation

### DIFF
--- a/Demo/GestureDemo/Program.swift
+++ b/Demo/GestureDemo/Program.swift
@@ -3,9 +3,7 @@ import VTree
 
 /// Complex `Message` type that has associated values.
 /// - Important: See `VTree.Message` comment documentation for more detail.
-///
-/// sourcery: VTreeMessage
-public enum Msg
+public enum Msg: AutoMessage
 {
     case increment
     case decrement

--- a/Sources/AutoMessage.swift
+++ b/Sources/AutoMessage.swift
@@ -1,0 +1,16 @@
+/// Phantom protocol that interacts with https://github.com/krzysztofzablocki/Sourcery
+/// to assist code-generation for **`enum Msg` with associated values**.
+///
+/// 1. Conform to `AutoMessage` protocol (instead of `Message`).
+/// 2. Run below script to automatically generate `extension Msg: Message`.
+///
+/// ```
+/// enum Msg: AutoMessage { case tap(GestureContext), longPress(GestureContext), ... }
+///
+/// // Run script:
+/// // $ <VTree-root>/Scripts/generate-message.sh <source-dir> <code-generated-dir>
+/// ```
+///
+/// - Note:
+/// `enum Msg` associated values must have single argument only that conforms to `MessageContext` protocol.
+public protocol AutoMessage {}

--- a/Sources/Message.swift
+++ b/Sources/Message.swift
@@ -26,12 +26,11 @@
 /// or use template-metaprogramming e.g. https://github.com/krzysztofzablocki/Sourcery
 /// to assist code-generation.
 ///
-/// 1. Add `/// sourcery: VTreeMessage` annotation
+/// 1. Conform to `AutoMessage` protocol (instead of `Message`).
 /// 2. Run below script to automatically generate `extension Msg: Message`.
 ///
 /// ```
-/// /// sourcery: VTreeMessage
-/// enum Msg: { case tap(GestureContext), longPress(GestureContext), ... }
+/// enum Msg: AutoMessage { case tap(GestureContext), longPress(GestureContext), ... }
 ///
 /// // Run script:
 /// // $ <VTree-root>/Scripts/generate-message.sh <source-dir> <code-generated-dir>

--- a/Templates/Message.stencil
+++ b/Templates/Message.stencil
@@ -1,5 +1,5 @@
 import VTree
-{% for enum in types.enums %}{% if enum.annotations.VTreeMessage %}
+{% for enum in types.implementing.AutoMessage %}{% if enum.kind == "enum" %}
 extension {{ enum.name }}: Message
 {
     public init?(rawValue: String)

--- a/Tests/Fixtures/MyMsg.swift
+++ b/Tests/Fixtures/MyMsg.swift
@@ -5,8 +5,7 @@ enum MyMsg: String, Message
     case msg1, msg2, msg3, msg4
 }
 
-// sourcery: VTreeMessage
-enum MyGestureMsg
+enum MyGestureMsg: AutoMessage
 {
     case msg1(GestureContext)
     case msg2(GestureContext)
@@ -14,8 +13,7 @@ enum MyGestureMsg
     case msg4(GestureContext)
 }
 
-// sourcery: VTreeMessage
-enum MyGestureMsg2
+enum MyGestureMsg2: AutoMessage
 {
     case msg1(GestureContext)
     case msg2(GestureContext)

--- a/VTree.xcodeproj/project.pbxproj
+++ b/VTree.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		1F34451A1DF3A10500D792E3 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3445191DF3A10500D792E3 /* Box.swift */; };
 		1F3C63991DF4C687009F5399 /* RButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3C63981DF4C687009F5399 /* RButton.swift */; };
 		1F3C63A11DF555B6009F5399 /* VTree+Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3C63A01DF555B6009F5399 /* VTree+Setup.swift */; };
+		1F3EBCD31E11626B002C0B29 /* AutoMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3EBCD21E11626B002C0B29 /* AutoMessage.swift */; };
 		1F43AFE11E0B9C5C00312DE7 /* MessageContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F43AFE01E0B9C5C00312DE7 /* MessageContext.swift */; };
 		1F43AFE31E0BA3B900312DE7 /* RawStringRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F43AFE21E0BA3B900312DE7 /* RawStringRepresentable.swift */; };
 		1F43BE301E0BE17A00312DE7 /* Message.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F43BE2F1E0BE17A00312DE7 /* Message.generated.swift */; };
@@ -126,6 +127,7 @@
 		1F3445191DF3A10500D792E3 /* Box.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Box.swift; sourceTree = "<group>"; };
 		1F3C63981DF4C687009F5399 /* RButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RButton.swift; sourceTree = "<group>"; };
 		1F3C63A01DF555B6009F5399 /* VTree+Setup.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "VTree+Setup.swift"; sourceTree = "<group>"; };
+		1F3EBCD21E11626B002C0B29 /* AutoMessage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AutoMessage.swift; sourceTree = "<group>"; };
 		1F433A981DF9B7D100DE4262 /* UniversalFramework_Base.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Base.xcconfig; sourceTree = "<group>"; };
 		1F433A991DF9B7D100DE4262 /* UniversalFramework_Framework.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Framework.xcconfig; sourceTree = "<group>"; };
 		1F433A9A1DF9B7D100DE4262 /* UniversalFramework_Test.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = UniversalFramework_Test.xcconfig; sourceTree = "<group>"; };
@@ -329,6 +331,7 @@
 				487FB0CC1DE2A51700F3465F /* SimpleEvent.swift */,
 				1F8602E31DFCD1280007911E /* GestureEvent.swift */,
 				1FBFDA9C1DE5604900094059 /* Message.swift */,
+				1F3EBCD21E11626B002C0B29 /* AutoMessage.swift */,
 				1F43AFE01E0B9C5C00312DE7 /* MessageContext.swift */,
 				1FBFDAA21DE580DA00094059 /* Messenger.swift */,
 			);
@@ -733,6 +736,7 @@
 				487FB0CD1DE2A51700F3465F /* SimpleEvent.swift in Sources */,
 				1F43AFE31E0BA3B900312DE7 /* RawStringRepresentable.swift in Sources */,
 				1FB7F4DF1DD814DB007B8E53 /* VGeneric.swift in Sources */,
+				1F3EBCD31E11626B002C0B29 /* AutoMessage.swift in Sources */,
 				484497181DDD806B00F5BB99 /* VTree+Reflection.swift in Sources */,
 				48034A601DD5ABEA00B8013D /* Diff.swift in Sources */,
 				48034A661DD5ADEE00B8013D /* AppKit+Ext.swift in Sources */,


### PR DESCRIPTION
Successor of #3.

Instead of using [Sourcery](https://github.com/krzysztofzablocki/Sourcery)'s comment-based annotation, we will use `protocol AutoMessage` that interacts with Stencil template. (Thanks @krzysztofzablocki for idea!)

### As Is

```swift
/// sourcery: VTreeMessage		
public enum Msg { ... }
```

### To Be

```swift
public enum Msg: AutoMessage { ... }
```