### PR TITLE
Refactor code, adding `VTreeDebugger`

### DIFF
--- a/Demo/DemoFramework/DemoFramework.h
+++ b/Demo/DemoFramework/DemoFramework.h
@@ -1,11 +1,3 @@
-//
-//  DemoFramework.h
-//  DemoFramework
-//
-//  Created by Yasuhiro Inami on 2017-04-16.
-//  Copyright © 2017 Yasuhiro Inami. All rights reserved.
-//
-
 #import <UIKit/UIKit.h>
 
 //! Project version number for DemoFramework.

--- a/Demo/DemoFramework/Program.swift
+++ b/Demo/DemoFramework/Program.swift
@@ -1,5 +1,6 @@
 import UIKit
 import VTree
+import VTreeDebugger
 
 /// Naive VTree renderer & event handler.
 /// - SeeAlso: https://github.com/inamiy/SwiftElm for more elegant solution.
@@ -7,19 +8,21 @@ public final class Program<Model, Msg: Message>
 {
     public private(set) var rootView: View?
 
-    private var _rootTree: VView<Msg>?
+    private var _rootTree: AnyVTree<Msg>?
 
     private var _model: Model
-    private let _view: (Model) -> VView<Msg>
+    private let _view: (Model) -> AnyVTree<Msg>
 
+    /// Flag for border-color & logging.
     private let _debug: Bool
 
-    public init(model: Model, update: @escaping (Model, Msg) -> (Model), view: @escaping (Model) -> VView<Msg>, debug: Bool = false)
+    public init<T: VTree>(debug: Bool = false, model: Model, update: @escaping (Model, Msg) -> Model?, view: @escaping (Model) -> T)
+        where T.MsgType == Msg
     {
         self._model = model
-        self._view = view
+        self._view = { *view($0) }
 
-        let initialTree = view(model)
+        let initialTree = self._view(model)
         let initialView = initialTree.createView()
 
         self._rootTree = initialTree
@@ -33,9 +36,10 @@ public final class Program<Model, Msg: Message>
 
         // Handle messages sent from `VTree`.
         Messenger.shared.handler = { [weak self] anyMsg in
-            guard let self_ = self, let msg = Msg(anyMsg) else { return }
+            guard let self_ = self, let msg = Msg(anyMsg),
+                let newModel = update(self_._model, msg) else { return }
 
-            self_._model = update(self_._model, msg)
+            self_._model = newModel
             self_._rerender()
         }
     }
@@ -69,4 +73,21 @@ public final class Program<Model, Msg: Message>
             Debug.printRecursiveDescription(newView)
         }
     }
+}
+
+/// Time-travelling `Program` with `VTreeDebugger`.
+///
+/// ## Usage
+/// ```
+/// // let program = Program(model: .initial, update: update, view: view)
+/// let program = debugProgram(debug: false, model: .initial, update: update, view: view)
+/// ```
+public func debugProgram<Model: VTreeDebugger.DebuggableModel, Msg: Message>(
+    debug: Bool = false,    // Flag for border-color & logging.
+    model: Model,
+    update: @escaping (Model, Msg) -> Model?,
+    view: @escaping (Model) -> VView<Msg>
+    ) -> Program<DebugModel<Model, Msg>, DebugMsg<Msg>>
+{
+    return Program(debug: debug, model: DebugModel(model), update: debugUpdate(update), view: debugView(view))
 }

--- a/Demo/GestureDemo/App.swift
+++ b/Demo/GestureDemo/App.swift
@@ -60,11 +60,11 @@ func update(_ model: Model, _ msg: Msg) -> Model
 {
     print(msg)  // Warning: impure logging
 
-    let argsString = msg.rawValue.arguments.map { "\($0)" }.joined(separator: "\n")
+    let argsString = msg.rawMessage.arguments.map { "\($0)" }.joined(separator: "\n")
     let cursor = Model.Cursor(msg: msg)
 
     return Model(
-        message: "\(msg.rawValue.funcName)\n\(argsString)",
+        message: "\(msg.rawMessage.funcName)\n\(argsString)",
         cursor: cursor
     )
 }
@@ -87,6 +87,7 @@ func view(model: Model) -> VView<Msg>
     func label(_ message: String) -> VLabel<Msg>
     {
         return VLabel(
+            key: key("label"),
             frame: CGRect(x: 0, y: 40, width: rootWidth, height: 300),
             backgroundColor: .clear,
             text: message,
@@ -98,6 +99,7 @@ func view(model: Model) -> VView<Msg>
     func noteLabel() -> VLabel<Msg>
     {
         return VLabel(
+            key: key("noteLabel"),
             frame: CGRect(x: 0, y: 350, width: rootWidth, height: 80),
             backgroundColor: .clear,
             text: "Tap anywhere to test gesture.",

--- a/Demo/GestureDemo/AppDelegate.swift
+++ b/Demo/GestureDemo/AppDelegate.swift
@@ -1,21 +1,34 @@
 import UIKit
 import DemoFramework
+import VTreeDebugger
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    var program: Program<Model, Msg>?
+    var program: Any?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool
     {
-        self.program = Program(model: .initial, update: update, view: view)
+//        let program = Program(model: .initial, update: update, view: view)
+        let program = debugProgram(debug: false, model: .initial, update: update, view: view)
+        self.program = program
 
         let mainView = self.window?.rootViewController?.view
         mainView?.backgroundColor = .white
-        mainView?.addSubview(self.program!.rootView!)
+        mainView?.addSubview(program.rootView!)
 
         return true
     }
 
+}
+
+// MARK: VTreeDebugger
+
+extension Model: VTreeDebugger.DebuggableModel
+{
+    var description: String
+    {
+        return "\(self.message)"
+    }
 }

--- a/Demo/GestureDemo/CodeGenerated/Message.generated.swift
+++ b/Demo/GestureDemo/CodeGenerated/Message.generated.swift
@@ -5,9 +5,9 @@ import VTree
 
 extension Msg: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             case "increment":
                 self = .increment
@@ -17,8 +17,8 @@ extension Msg: Message
 
             // .tap(GestureContext)
             case "tap":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .tap(context)
                 }
                 else {
@@ -27,8 +27,8 @@ extension Msg: Message
 
             // .pan(PanGestureContext)
             case "pan":
-                let arguments = rawValue.arguments
-                if let context = PanGestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = PanGestureContext(rawArguments: arguments) {
                     self = .pan(context)
                 }
                 else {
@@ -37,8 +37,8 @@ extension Msg: Message
 
             // .longPress(GestureContext)
             case "longPress":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .longPress(context)
                 }
                 else {
@@ -47,8 +47,8 @@ extension Msg: Message
 
             // .swipe(GestureContext)
             case "swipe":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .swipe(context)
                 }
                 else {
@@ -57,8 +57,8 @@ extension Msg: Message
 
             // .pinch(PinchGestureContext)
             case "pinch":
-                let arguments = rawValue.arguments
-                if let context = PinchGestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = PinchGestureContext(rawArguments: arguments) {
                     self = .pinch(context)
                 }
                 else {
@@ -67,8 +67,8 @@ extension Msg: Message
 
             // .rotation(RotationGestureContext)
             case "rotation":
-                let arguments = rawValue.arguments
-                if let context = RotationGestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = RotationGestureContext(rawArguments: arguments) {
                     self = .rotation(context)
                 }
                 else {
@@ -77,8 +77,8 @@ extension Msg: Message
 
             // .dummy(DummyContext)
             case "dummy":
-                let arguments = rawValue.arguments
-                if let context = DummyContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = DummyContext(rawArguments: arguments) {
                     self = .dummy(context)
                 }
                 else {
@@ -90,7 +90,7 @@ extension Msg: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 
@@ -101,25 +101,25 @@ extension Msg: Message
                 return RawMessage(funcName: "decrement", arguments: [])
 
             case let .tap(context):
-                return RawMessage(funcName: "tap", arguments: context.rawValue)
+                return RawMessage(funcName: "tap", arguments: context.rawArguments)
 
             case let .pan(context):
-                return RawMessage(funcName: "pan", arguments: context.rawValue)
+                return RawMessage(funcName: "pan", arguments: context.rawArguments)
 
             case let .longPress(context):
-                return RawMessage(funcName: "longPress", arguments: context.rawValue)
+                return RawMessage(funcName: "longPress", arguments: context.rawArguments)
 
             case let .swipe(context):
-                return RawMessage(funcName: "swipe", arguments: context.rawValue)
+                return RawMessage(funcName: "swipe", arguments: context.rawArguments)
 
             case let .pinch(context):
-                return RawMessage(funcName: "pinch", arguments: context.rawValue)
+                return RawMessage(funcName: "pinch", arguments: context.rawArguments)
 
             case let .rotation(context):
-                return RawMessage(funcName: "rotation", arguments: context.rawValue)
+                return RawMessage(funcName: "rotation", arguments: context.rawArguments)
 
             case let .dummy(context):
-                return RawMessage(funcName: "dummy", arguments: context.rawValue)
+                return RawMessage(funcName: "dummy", arguments: context.rawArguments)
 
         }
     }

--- a/Demo/GestureDemo/CodeGenerated/MessageContext.generated.swift
+++ b/Demo/GestureDemo/CodeGenerated/MessageContext.generated.swift
@@ -11,14 +11,14 @@ import VTree
 
 extension DummyContext: MessageContext
 {
-    public init?(rawValue: [Any])
+    public init?(rawArguments: [Any])
     {
-        guard rawValue.count == 0 else { return nil }
+        guard rawArguments.count == 0 else { return nil }
 
         self = DummyContext()
     }
 
-    public var rawValue: [Any]
+    public var rawArguments: [Any]
     {
         return []
     }

--- a/Demo/SimpleDemo/App.swift
+++ b/Demo/SimpleDemo/App.swift
@@ -54,7 +54,7 @@ func view(model: Model) -> VView<Msg>
     {
         return VLabel(
             backgroundColor: .clear,
-            text: spellOut(count),
+            text: "\(count)",
             textAlignment: .center,
             font: .systemFont(ofSize: 48),
             flexbox: Flexbox.Node(

--- a/Demo/SimpleDemo/AppDelegate.swift
+++ b/Demo/SimpleDemo/AppDelegate.swift
@@ -1,21 +1,34 @@
 import UIKit
 import DemoFramework
+import VTreeDebugger
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
-    var program: Program<Model, Msg>?
+    var program: Any?
 
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool
     {
-        self.program = Program(model: .initial, update: update, view: view)
+//        let program = Program(model: .initial, update: update, view: view)
+        let program = debugProgram(debug: false, model: .initial, update: update, view: view)
+        self.program = program
 
         let mainView = self.window?.rootViewController?.view
         mainView?.backgroundColor = .white
-        mainView?.addSubview(self.program!.rootView!)
+        mainView?.addSubview(program.rootView!)
 
         return true
     }
 
+}
+
+// MARK: VTreeDebugger
+
+extension Model: VTreeDebugger.DebuggableModel
+{
+    var description: String
+    {
+        return "\(self.count)"
+    }
 }

--- a/Demo/SimpleDemo/CodeGenerated/Message.generated.swift
+++ b/Demo/SimpleDemo/CodeGenerated/Message.generated.swift
@@ -5,9 +5,9 @@ import VTree
 
 extension Msg: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             case "increment":
                 self = .increment
@@ -20,7 +20,7 @@ extension Msg: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 

--- a/Sources/CodeGenerated/MessageContext.generated.swift
+++ b/Sources/CodeGenerated/MessageContext.generated.swift
@@ -11,18 +11,18 @@ import AppKit
 
 extension GestureContext: MessageContext
 {
-    public init?(rawValue: [Any])
+    public init?(rawArguments: [Any])
     {
-        guard rawValue.count == 2 else { return nil }
+        guard rawArguments.count == 2 else { return nil }
 
-        guard let state = rawValue[1 - 1] as? GestureState else { return nil }
+        guard let state = rawArguments[1 - 1] as? GestureState else { return nil }
 
-        guard let location = rawValue[2 - 1] as? CGPoint else { return nil }
+        guard let location = rawArguments[2 - 1] as? CGPoint else { return nil }
 
         self = GestureContext(state: state, location: location)
     }
 
-    public var rawValue: [Any]
+    public var rawArguments: [Any]
     {
         return [state, location]
     }
@@ -30,20 +30,20 @@ extension GestureContext: MessageContext
 
 extension PanGestureContext: MessageContext
 {
-    public init?(rawValue: [Any])
+    public init?(rawArguments: [Any])
     {
-        guard rawValue.count == 3 else { return nil }
+        guard rawArguments.count == 3 else { return nil }
 
-        guard let state = rawValue[1 - 1] as? GestureState else { return nil }
+        guard let state = rawArguments[1 - 1] as? GestureState else { return nil }
 
-        guard let location = rawValue[2 - 1] as? CGPoint else { return nil }
+        guard let location = rawArguments[2 - 1] as? CGPoint else { return nil }
 
-        guard let velocity = rawValue[3 - 1] as? CGPoint else { return nil }
+        guard let velocity = rawArguments[3 - 1] as? CGPoint else { return nil }
 
         self = PanGestureContext(state: state, location: location, velocity: velocity)
     }
 
-    public var rawValue: [Any]
+    public var rawArguments: [Any]
     {
         return [state, location, velocity]
     }
@@ -51,22 +51,22 @@ extension PanGestureContext: MessageContext
 
 extension PinchGestureContext: MessageContext
 {
-    public init?(rawValue: [Any])
+    public init?(rawArguments: [Any])
     {
-        guard rawValue.count == 4 else { return nil }
+        guard rawArguments.count == 4 else { return nil }
 
-        guard let state = rawValue[1 - 1] as? GestureState else { return nil }
+        guard let state = rawArguments[1 - 1] as? GestureState else { return nil }
 
-        guard let location = rawValue[2 - 1] as? CGPoint else { return nil }
+        guard let location = rawArguments[2 - 1] as? CGPoint else { return nil }
 
-        guard let scale = rawValue[3 - 1] as? CGFloat else { return nil }
+        guard let scale = rawArguments[3 - 1] as? CGFloat else { return nil }
 
-        guard let velocity = rawValue[4 - 1] as? CGFloat else { return nil }
+        guard let velocity = rawArguments[4 - 1] as? CGFloat else { return nil }
 
         self = PinchGestureContext(state: state, location: location, scale: scale, velocity: velocity)
     }
 
-    public var rawValue: [Any]
+    public var rawArguments: [Any]
     {
         return [state, location, scale, velocity]
     }
@@ -74,22 +74,22 @@ extension PinchGestureContext: MessageContext
 
 extension RotationGestureContext: MessageContext
 {
-    public init?(rawValue: [Any])
+    public init?(rawArguments: [Any])
     {
-        guard rawValue.count == 4 else { return nil }
+        guard rawArguments.count == 4 else { return nil }
 
-        guard let state = rawValue[1 - 1] as? GestureState else { return nil }
+        guard let state = rawArguments[1 - 1] as? GestureState else { return nil }
 
-        guard let location = rawValue[2 - 1] as? CGPoint else { return nil }
+        guard let location = rawArguments[2 - 1] as? CGPoint else { return nil }
 
-        guard let rotation = rawValue[3 - 1] as? CGFloat else { return nil }
+        guard let rotation = rawArguments[3 - 1] as? CGFloat else { return nil }
 
-        guard let velocity = rawValue[4 - 1] as? CGFloat else { return nil }
+        guard let velocity = rawArguments[4 - 1] as? CGFloat else { return nil }
 
         self = RotationGestureContext(state: state, location: location, rotation: rotation, velocity: velocity)
     }
 
-    public var rawValue: [Any]
+    public var rawArguments: [Any]
     {
         return [state, location, rotation, velocity]
     }

--- a/Sources/MessageContext.swift
+++ b/Sources/MessageContext.swift
@@ -9,10 +9,10 @@
 /// Protocol that represents `enum Msg`'s "associated values (arguments)",
 /// interacting with https://github.com/krzysztofzablocki/Sourcery.
 /// - SeeAlso: Templates/Message.stencil
-public protocol MessageContext: RawRepresentable
+public protocol MessageContext
 {
-    init?(rawValue: [Any])
-    var rawValue: [Any] { get }
+    init?(rawArguments: [Any])
+    var rawArguments: [Any] { get }
 }
 
 // MARK: GestureContext

--- a/Sources/Patch.swift
+++ b/Sources/Patch.swift
@@ -1,7 +1,5 @@
 import Flexbox
 
-internal typealias FlexboxFrames = [Int: [CGRect]]
-
 /// Container of `PatchStep`s.
 public struct Patch<Msg: Message>
 {
@@ -10,7 +8,7 @@ public struct Patch<Msg: Message>
 
     internal let oldTree: AnyVTree<Msg>
     internal let steps: Steps
-    internal let flexboxFrames: FlexboxFrames
+    internal let flexboxFrames: [CGRect]
 }
 
 extension Patch: CustomStringConvertible

--- a/Sources/UIView+Ext.swift
+++ b/Sources/UIView+Ext.swift
@@ -1,0 +1,20 @@
+#if os(iOS) || os(tvOS)
+
+import UIKit
+
+extension UIView
+{
+    // MARK: KVC-compliant properties
+
+    public var vtree_cornerRadius: CGFloat
+    {
+        get {
+            return self.layer.cornerRadius
+        }
+        set {
+            self.layer.cornerRadius = newValue
+        }
+    }
+}
+
+#endif

--- a/Sources/VButton.swift
+++ b/Sources/VButton.swift
@@ -26,6 +26,7 @@ public final class VButton<Msg: Message>: VTree, PropsReflectable
         backgroundColor: Color? = nil,
         alpha: CGFloat = 1,
         isHidden: Bool = false,
+        cornerRadius: CGFloat = 0,
         title: String? = nil,
         titleColor: Color? = nil,
         font: Font? = nil,
@@ -55,7 +56,7 @@ public final class VButton<Msg: Message>: VTree, PropsReflectable
 
         self._handlers = handlers
         self.children = children
-        self.propsData = PropsData(frame: frame, backgroundColor: backgroundColor, alpha: alpha, hidden: isHidden, vtree_title: title, vtree_titleColor: titleColor, vtree_font: font, vtree_numberOfLines: numberOfLines)
+        self.propsData = PropsData(frame: frame, backgroundColor: backgroundColor, alpha: alpha, hidden: isHidden, vtree_cornerRadius: cornerRadius, vtree_title: title, vtree_titleColor: titleColor, vtree_font: font, vtree_numberOfLines: numberOfLines)
     }
 
     public var propsKeysForMeasure: [String]
@@ -68,14 +69,13 @@ public final class VButton<Msg: Message>: VTree, PropsReflectable
         return self._handlers.map { (.control($0), $1) }
     }
 
-    public func createView<Msg2: Message>(_ config: ViewConfig<Msg, Msg2>) -> Button
+    public func createView<Msg2: Message>(_ msgMapper: @escaping (Msg) -> Msg2) -> Button
     {
         let view = Button()
-
-        self._setupView(view, config: config)
+        self._setupView(view, msgMapper: msgMapper)
 
         for (event, msg) in self._handlers {
-            let msg2 = config._msgMapper(msg)
+            let msg2 = msgMapper(msg)
             view.vtree.addHandler(for: event) { _ in
                 Messenger.shared.send(AnyMsg(msg2))
             }
@@ -95,6 +95,8 @@ public struct VButtonPropsData
     fileprivate let backgroundColor: Color?
     fileprivate let alpha: CGFloat
     fileprivate let hidden: Bool
+
+    fileprivate let vtree_cornerRadius: CGFloat
 
     fileprivate let vtree_title: String?
     fileprivate let vtree_titleColor: Color?

--- a/Sources/VGeneric.swift
+++ b/Sources/VGeneric.swift
@@ -30,12 +30,10 @@ public final class VGeneric<V: View, Msg: Message>: VTree
         self.children = children
     }
 
-    public func createView<Msg2: Message>(_ config: ViewConfig<Msg, Msg2>) -> V
+    public func createView<Msg2: Message>(_ msgMapper: @escaping (Msg) -> Msg2) -> V
     {
         let view = V()
-
-        self._setupView(view, config: config)
-
+        self._setupView(view, msgMapper: msgMapper)
         return view
     }
 }

--- a/Sources/VImageView.swift
+++ b/Sources/VImageView.swift
@@ -24,6 +24,7 @@ public final class VImageView<Msg: Message>: VTree, PropsReflectable
         backgroundColor: Color? = nil,
         alpha: CGFloat = 1,
         isHidden: Bool = false,
+        cornerRadius: CGFloat = 0,
         image: Image? = nil,
         flexbox: Flexbox.Node? = nil,
         gestures: [GestureEvent<Msg>] = [],
@@ -34,15 +35,13 @@ public final class VImageView<Msg: Message>: VTree, PropsReflectable
         self.flexbox = flexbox
         self.gestures = gestures
         self.children = children
-        self.propsData = PropsData(frame: frame, backgroundColor: backgroundColor, alpha: alpha, hidden: isHidden, image: image)
+        self.propsData = PropsData(frame: frame, backgroundColor: backgroundColor, alpha: alpha, hidden: isHidden, vtree_cornerRadius: cornerRadius, image: image)
     }
 
-    public func createView<Msg2: Message>(_ config: ViewConfig<Msg, Msg2>) -> ImageView
+    public func createView<Msg2: Message>(_ msgMapper: @escaping (Msg) -> Msg2) -> ImageView
     {
         let view = ImageView()
-
-        self._setupView(view, config: config)
-
+        self._setupView(view, msgMapper: msgMapper)
         return view
     }
 }
@@ -57,6 +56,8 @@ public struct VImageViewPropsData
     fileprivate let backgroundColor: Color?
     fileprivate let alpha: CGFloat
     fileprivate let hidden: Bool
+
+    fileprivate let vtree_cornerRadius: CGFloat
 
     fileprivate let image: Image?
 }

--- a/Sources/VLabel.swift
+++ b/Sources/VLabel.swift
@@ -27,7 +27,9 @@ public final class VLabel<Msg: Message>: VTree, PropsReflectable
         backgroundColor: Color? = nil,
         alpha: CGFloat = 1,
         isHidden: Bool = false,
+        cornerRadius: CGFloat = 0,
         text: String? = nil,
+        textColor: Color? = nil,
         textAlignment: NSTextAlignment = .left,
         font: Font? = nil,
         numberOfLines: Int = 0,
@@ -61,7 +63,7 @@ public final class VLabel<Msg: Message>: VTree, PropsReflectable
 
         self.gestures = gestures
         self.children = children
-        self.propsData = PropsData(frame: frame, backgroundColor: backgroundColor, alpha: alpha, hidden: isHidden, text: text, textAlignment: textAlignment.rawValue, font: font, vtree_numberOfLines: numberOfLines)
+        self.propsData = PropsData(frame: frame, backgroundColor: backgroundColor, alpha: alpha, hidden: isHidden, vtree_cornerRadius: cornerRadius, text: text, textColor: textColor, textAlignment: textAlignment.rawValue, font: font, vtree_numberOfLines: numberOfLines)
     }
 
     public var propsKeysForMeasure: [String]
@@ -69,12 +71,10 @@ public final class VLabel<Msg: Message>: VTree, PropsReflectable
         return ["font", "text", "vtree_numberOfLines"]
     }
 
-    public func createView<Msg2: Message>(_ config: ViewConfig<Msg, Msg2>) -> Label
+    public func createView<Msg2: Message>(_ msgMapper: @escaping (Msg) -> Msg2) -> Label
     {
         let view = Label()
-
-        self._setupView(view, config: config)
-
+        self._setupView(view, msgMapper: msgMapper)
         return view
     }
 }
@@ -90,7 +90,10 @@ public struct VLabelPropsData
     fileprivate let alpha: CGFloat
     fileprivate let hidden: Bool
 
+    fileprivate let vtree_cornerRadius: CGFloat
+
     fileprivate let text: String?
+    fileprivate let textColor: Color?
     fileprivate let textAlignment: NSTextAlignment.RawValue
     fileprivate let font: Font?
 

--- a/Sources/VTree.swift
+++ b/Sources/VTree.swift
@@ -51,25 +51,7 @@ public protocol VTree
     /// - Note:
     /// This method is mainly used for internal purpose.
     /// To create a view hierarchy from root VTree, use `VTree.createView()` instead.
-    func createView<Msg2: Message>(_ config: ViewConfig<MsgType, Msg2>) -> ViewType
-}
-
-// MARK: ViewConfig
-
-/// View configuration type used in `VTree.createView`.
-public struct ViewConfig<Msg: Message, Msg2: Message>
-{
-    /// A lazy mapping function that is used in `AnyVTree.map`.
-    internal let _msgMapper: (Msg) -> Msg2
-
-    /// A flag that skips descendent duplicated flexbox calculation.
-    internal let _skipsFlexbox: Bool
-
-    internal init(msgMapper: @escaping (Msg) -> Msg2, skipsFlexbox: Bool)
-    {
-        self._msgMapper = msgMapper
-        self._skipsFlexbox = skipsFlexbox
-    }
+    func createView<Msg2: Message>(_ msgMapper: @escaping (MsgType) -> Msg2) -> ViewType
 }
 
 // MARK: Default implementation
@@ -97,8 +79,7 @@ extension VTree
     /// Entrypoint of creating a root view from `VTree`.
     public func createView() -> ViewType
     {
-        let config = ViewConfig<MsgType, MsgType>(msgMapper: { $0 }, skipsFlexbox: false)
-        return self.createView(config)
+        return self.createView { $0 }
     }
 }
 
@@ -107,7 +88,7 @@ extension VTree
 extension VTree
 {
     /// - Returns: `nil` if `flexbox` doesn't exist.
-    internal var _flexboxTree: Flexbox.Node?
+    internal var _flexboxTree: Flexbox.Node
     {
         /// Creates complete `Flexbox.Node`s from VTree children, even if child's flexbox is missing.
         ///
@@ -117,48 +98,29 @@ extension VTree
         func flexboxChildren(_ vtreeChildren: [AnyVTree<MsgType>]) -> [Flexbox.Node]
         {
             return vtreeChildren.map { childTree in
-                if let flexboxTree = childTree._flexboxTree {
-                    return flexboxTree
-                }
-                else {
-                    // If `childTree.flexbox` doesn't exist, use old-fasioned `frame` instead
-                    // and treat `flexbox.positionType` as `.absolute`.
-                    //
-                    // - Note:
-                    // Returning empty `Node()` or truncating it from `flexboxTree`
-                    // will malform view-indexing, so never do it.
-                    var frame = childTree.props["frame"] as? CGRect ?? .zero
-                    if frame == .null {
-                        frame = .zero
-                    }
-                    return Flexbox.Node(
-                        size: frame.size,
-                        children: flexboxChildren(childTree.children),
-                        positionType: .absolute,
-                        position: Edges(left: frame.origin.x, top: frame.origin.y)
-                    )
-                }
+                return childTree._flexboxTree
             }
         }
 
-        return self._canonicalFlexbox.map {
+        return {
             return Flexbox.Node(size: $0.size, minSize: $0.minSize, maxSize: $0.maxSize, children: flexboxChildren(self.children), flexDirection: $0.flexDirection, flexWrap: $0.flexWrap, justifyContent: $0.justifyContent, alignContent: $0.alignContent, alignItems: $0.alignItems, alignSelf: $0.alignSelf, flex: $0.flex, flexGrow: $0.flexGrow, flexShrink: $0.flexShrink, flexBasis: $0.flexBasis, direction: $0.direction, overflow: $0.overflow, positionType: $0.positionType, position: $0.position, margin: $0.margin, padding: $0.padding, border: $0.border, measure: $0.measure)
-        }
+        }(self._canonicalFlexbox)
     }
 
     /// Formal flexbox that also takes care of `props["frame"]`
     /// by converting it to `flexbox.size` and `flexbox.position`.
     ///
     /// - Returns: `nil` if `flexbox` doesn't exist.
-    private var _canonicalFlexbox: Flexbox.Node?
+    private var _canonicalFlexbox: Flexbox.Node
     {
         if let frame = self.props["frame"] as? CGRect, frame != .null {
             return self.flexbox.map {
                 return Flexbox.Node(size: frame.size, minSize: $0.minSize, maxSize: $0.maxSize, children: $0.children, flexDirection: $0.flexDirection, flexWrap: $0.flexWrap, justifyContent: $0.justifyContent, alignContent: $0.alignContent, alignItems: $0.alignItems, alignSelf: $0.alignSelf, flex: $0.flex, flexGrow: $0.flexGrow, flexShrink: $0.flexShrink, flexBasis: $0.flexBasis, direction: $0.direction, overflow: $0.overflow, positionType: .absolute, position: Edges(left: frame.origin.x, top: frame.origin.y), margin: $0.margin, padding: $0.padding, border: $0.border, measure: $0.measure)
             }
+                ?? Flexbox.Node(size: frame.size, positionType: .absolute, position: Edges(left: frame.origin.x, top: frame.origin.y))
         }
         else {
-            return self.flexbox
+            return self.flexbox ?? Flexbox.Node()
         }
     }
 }

--- a/Sources/VView.swift
+++ b/Sources/VView.swift
@@ -24,6 +24,7 @@ public final class VView<Msg: Message>: VTree, PropsReflectable
         backgroundColor: Color? = nil,
         alpha: CGFloat = 1,
         isHidden: Bool = false,
+        cornerRadius: CGFloat = 0,
         flexbox: Flexbox.Node? = nil,
         gestures: [GestureEvent<Msg>] = [],
         children: [AnyVTree<Msg>] = []
@@ -33,15 +34,13 @@ public final class VView<Msg: Message>: VTree, PropsReflectable
         self.flexbox = flexbox
         self.gestures = gestures
         self.children = children
-        self.propsData = PropsData(frame: frame, backgroundColor: backgroundColor, alpha: alpha, hidden: isHidden)
+        self.propsData = PropsData(frame: frame, backgroundColor: backgroundColor, alpha: alpha, hidden: isHidden, vtree_cornerRadius: cornerRadius)
     }
 
-    public func createView<Msg2: Message>(_ config: ViewConfig<Msg, Msg2>) -> View
+    public func createView<Msg2: Message>(_ msgMapper: @escaping (Msg) -> Msg2) -> View
     {
         let view = View()
-
-        self._setupView(view, config: config)
-
+        self._setupView(view, msgMapper: msgMapper)
         return view
     }
 }
@@ -56,4 +55,6 @@ public struct VViewPropsData
     fileprivate let backgroundColor: Color?
     fileprivate let alpha: CGFloat
     fileprivate let hidden: Bool
+
+    fileprivate let vtree_cornerRadius: CGFloat
 }

--- a/Templates/Message.stencil
+++ b/Templates/Message.stencil
@@ -2,17 +2,17 @@
 {% for enum in types.implementing.AutoMessage %}{% if enum.kind == "enum" %}
 extension {{ enum.name }}: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 {% for case in enum.cases %}{% if case.associatedValues.count == 0 %}
             case "{{ case.name }}":
                 self = .{{ case.name }}
-{% else %}{% if case.associatedValues.count == 1 and case.associatedValues.0.type.implements.MessageContext %}
+{% else %}{% if case.associatedValues.count == 1 and case.associatedValues.0.type.implements.MessageContext or case.associatedValues.annotations.MessageContext %}
             // .{{ case.name }}({{ case.associatedValues.0.typeName }})
             case "{{ case.name }}":
-                let arguments = rawValue.arguments
-                if let context = {{ case.associatedValues.0.typeName }}(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = {{ case.associatedValues.0.typeName }}(rawArguments: arguments) {
                     self = .{{ case.name }}(context)
                 }
                 else {
@@ -24,15 +24,15 @@ extension {{ enum.name }}: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 {% for case in enum.cases %}{% if case.associatedValues.count == 0 %}
             case .{{ case.name }}:
                 return RawMessage(funcName: "{{ case.name }}", arguments: [])
-{% else %}{% if case.associatedValues.count == 1 and case.associatedValues.0.type.implements.MessageContext %}
+{% else %}{% if case.associatedValues.count == 1 and case.associatedValues.0.type.implements.MessageContext or case.associatedValues.annotations.MessageContext %}
             case let .{{ case.name }}(context):
-                return RawMessage(funcName: "{{ case.name }}", arguments: context.rawValue)
+                return RawMessage(funcName: "{{ case.name }}", arguments: context.rawArguments)
 {% endif %}{% endif %}{% endfor %}
         }
     }

--- a/Templates/MessageContext.stencil
+++ b/Templates/MessageContext.stencil
@@ -8,16 +8,16 @@ import AppKit
 {% for type in types.structs %}{% if type.implements.AutoMessageContext or argument.internal and type.implements._AutoMessageContext %}
 extension {{ type.name }}: MessageContext
 {
-    public init?(rawValue: [Any])
+    public init?(rawArguments: [Any])
     {
-        guard rawValue.count == {{ type.variables.count }} else { return nil }
+        guard rawArguments.count == {{ type.variables.count }} else { return nil }
 {% for variable in type.variables %}
-        guard let {{ variable.name }} = rawValue[{{ forloop.counter }} - 1] as? {{ variable.typeName }} else { return nil }
+        guard let {{ variable.name }} = rawArguments[{{ forloop.counter }} - 1] as? {{ variable.typeName }} else { return nil }
 {% endfor %}
         self = {{ type.name }}({% for variable in type.variables %}{{ variable.name }}: {{ variable.name }}{% if not forloop.last %}, {% endif %}{% endfor %})
     }
 
-    public var rawValue: [Any]
+    public var rawArguments: [Any]
     {
         return [{% for variable in type.variables %}{{ variable.name }}{% if not forloop.last %}, {% endif %}{% endfor %}]
     }

--- a/Tests/Fixtures/CodeGenerated/Message.generated.swift
+++ b/Tests/Fixtures/CodeGenerated/Message.generated.swift
@@ -5,14 +5,14 @@ import VTree
 
 extension MyGestureMsg: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             // .msg1(GestureContext)
             case "msg1":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .msg1(context)
                 }
                 else {
@@ -21,8 +21,8 @@ extension MyGestureMsg: Message
 
             // .msg2(GestureContext)
             case "msg2":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .msg2(context)
                 }
                 else {
@@ -31,8 +31,8 @@ extension MyGestureMsg: Message
 
             // .msg3(GestureContext)
             case "msg3":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .msg3(context)
                 }
                 else {
@@ -41,8 +41,8 @@ extension MyGestureMsg: Message
 
             // .msg4(GestureContext)
             case "msg4":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .msg4(context)
                 }
                 else {
@@ -54,21 +54,21 @@ extension MyGestureMsg: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 
             case let .msg1(context):
-                return RawMessage(funcName: "msg1", arguments: context.rawValue)
+                return RawMessage(funcName: "msg1", arguments: context.rawArguments)
 
             case let .msg2(context):
-                return RawMessage(funcName: "msg2", arguments: context.rawValue)
+                return RawMessage(funcName: "msg2", arguments: context.rawArguments)
 
             case let .msg3(context):
-                return RawMessage(funcName: "msg3", arguments: context.rawValue)
+                return RawMessage(funcName: "msg3", arguments: context.rawArguments)
 
             case let .msg4(context):
-                return RawMessage(funcName: "msg4", arguments: context.rawValue)
+                return RawMessage(funcName: "msg4", arguments: context.rawArguments)
 
         }
     }
@@ -76,14 +76,14 @@ extension MyGestureMsg: Message
 
 extension MyGestureMsg2: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             // .msg1(GestureContext)
             case "msg1":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .msg1(context)
                 }
                 else {
@@ -92,8 +92,8 @@ extension MyGestureMsg2: Message
 
             // .msg2(GestureContext)
             case "msg2":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .msg2(context)
                 }
                 else {
@@ -102,8 +102,8 @@ extension MyGestureMsg2: Message
 
             // .msg3(GestureContext)
             case "msg3":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .msg3(context)
                 }
                 else {
@@ -112,8 +112,8 @@ extension MyGestureMsg2: Message
 
             // .msg4(GestureContext)
             case "msg4":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .msg4(context)
                 }
                 else {
@@ -125,21 +125,21 @@ extension MyGestureMsg2: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 
             case let .msg1(context):
-                return RawMessage(funcName: "msg1", arguments: context.rawValue)
+                return RawMessage(funcName: "msg1", arguments: context.rawArguments)
 
             case let .msg2(context):
-                return RawMessage(funcName: "msg2", arguments: context.rawValue)
+                return RawMessage(funcName: "msg2", arguments: context.rawArguments)
 
             case let .msg3(context):
-                return RawMessage(funcName: "msg3", arguments: context.rawValue)
+                return RawMessage(funcName: "msg3", arguments: context.rawArguments)
 
             case let .msg4(context):
-                return RawMessage(funcName: "msg4", arguments: context.rawValue)
+                return RawMessage(funcName: "msg4", arguments: context.rawArguments)
 
         }
     }
@@ -147,9 +147,9 @@ extension MyGestureMsg2: Message
 
 extension MyMsg: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             case "msg1":
                 self = .msg1
@@ -168,7 +168,7 @@ extension MyMsg: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 
@@ -190,9 +190,9 @@ extension MyMsg: Message
 
 extension MyMsg2: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             case "test1":
                 self = .test1
@@ -205,7 +205,7 @@ extension MyMsg2: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 

--- a/Tests/Fixtures/VPhantom.swift
+++ b/Tests/Fixtures/VPhantom.swift
@@ -18,12 +18,12 @@ public final class VPhantom<👻>: VTree
         self.children = children
     }
 
-    public func createView<Msg2: Message>(_ config: ViewConfig<NoMsg, Msg2>) -> View
+    public func createView<Msg2: Message>(_ msgMapper: @escaping (NoMsg) -> Msg2) -> View
     {
         let view = View()
 
         for child in self.children {
-            view.addSubview(child.createView(config))
+            view.addSubview(child.createView(msgMapper))
         }
 
         return view

--- a/Tests/Fixtures/VTree+Helper.swift
+++ b/Tests/Fixtures/VTree+Helper.swift
@@ -6,22 +6,20 @@ extension VTree
     /// `createView(config)` helper which ignores flexbox.
     func createTestView<Msg2: Message>(_ msgMapper: @escaping (MsgType) -> Msg2) -> ViewType
     {
-        let config = ViewConfig<MsgType, Msg2>(msgMapper: msgMapper, skipsFlexbox: false)
-        return self.createView(config)
+        return self.createView(msgMapper)
     }
 }
 
 /// `_diffChildren` helper which ignores flexbox.
 func testDiffChildren<Msg: Message>(old oldChildren: [AnyVTree<Msg>], new newChildren: [AnyVTree<Msg>], steps: inout Patch<Msg>.Steps, parentIndex: Int)
 {
-    var flexboxFrames = [Int: [CGRect]]()
+    var layoutDirty = LayoutDirtyReason.none
 
     _diffChildren(
         old: oldChildren,
         new: newChildren,
+        parentIndex: 0,
         steps: &steps,
-        flexboxFrames: &flexboxFrames,
-        skipsFlexbox: false,
-        parentIndex: 0
+        layoutDirty: &layoutDirty
     )
 }

--- a/VTree.xcodeproj/project.pbxproj
+++ b/VTree.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		1F21F61B1DD6227B00A70C25 /* Helper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F21F6191DD621B000A70C25 /* Helper.swift */; };
 		1F21F6201DD6269800A70C25 /* Patch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F21F61E1DD6265400A70C25 /* Patch.swift */; };
 		1F21F6211DD6269F00A70C25 /* Apply.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F21F61C1DD6263600A70C25 /* Apply.swift */; };
+		1F2AA9431EAC6DCC000D33E7 /* VTreeDebugger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F4C6F471EAB8EA700D641AC /* VTreeDebugger.framework */; };
+		1F2AA9441EAC6DCC000D33E7 /* VTreeDebugger.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F4C6F471EAB8EA700D641AC /* VTreeDebugger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		1F34451A1DF3A10500D792E3 /* Box.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3445191DF3A10500D792E3 /* Box.swift */; };
 		1F3C63991DF4C687009F5399 /* RButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3C63981DF4C687009F5399 /* RButton.swift */; };
 		1F3C63A11DF555B6009F5399 /* VTree+Setup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F3C63A01DF555B6009F5399 /* VTree+Setup.swift */; };
@@ -45,6 +47,15 @@
 		1F4A5A111EA3323100B00F93 /* Gesture+Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A5A0B1EA3323100B00F93 /* Gesture+Debug.swift */; };
 		1F4A5A121EA3323100B00F93 /* Helpers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A5A0C1EA3323100B00F93 /* Helpers.swift */; };
 		1F4A5A141EA3323100B00F93 /* Program.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4A5A0E1EA3323100B00F93 /* Program.swift */; };
+		1F4C6F4B1EAB8EA700D641AC /* VTreeDebugger.h in Headers */ = {isa = PBXBuildFile; fileRef = 1F4C6F491EAB8EA700D641AC /* VTreeDebugger.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1F4C6F4E1EAB8EA700D641AC /* VTreeDebugger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F4C6F471EAB8EA700D641AC /* VTreeDebugger.framework */; };
+		1F4C6F4F1EAB8EA700D641AC /* VTreeDebugger.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F4C6F471EAB8EA700D641AC /* VTreeDebugger.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1F4C6F541EAB8ECD00D641AC /* Debugger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4C6F531EAB8ECD00D641AC /* Debugger.swift */; };
+		1F4C6F581EAB8F9800D641AC /* Message.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4C6F561EAB8F9800D641AC /* Message.generated.swift */; };
+		1F4C6F591EAB8F9800D641AC /* MessageContext.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4C6F571EAB8F9800D641AC /* MessageContext.generated.swift */; };
+		1F4C6F5B1EAB95AD00D641AC /* VTree.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 48FB18A71DD584520027B8B1 /* VTree.framework */; };
+		1F4C6F5E1EABA15700D641AC /* VTreeDebugger.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F4C6F471EAB8EA700D641AC /* VTreeDebugger.framework */; };
+		1F4C6F601EABB08E00D641AC /* Slider.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F4C6F5F1EABB08E00D641AC /* Slider.swift */; };
 		1F517BD31E3B926A00A77053 /* Message.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F517BD21E3B926A00A77053 /* Message.generated.swift */; };
 		1F5DECAD1DEAA19500BC6B1B /* KeyCacheSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DECAB1DEAA16200BC6B1B /* KeyCacheSpec.swift */; };
 		1F5DECAF1DEAA58A00BC6B1B /* LazyMapSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DECAE1DEAA58A00BC6B1B /* LazyMapSpec.swift */; };
@@ -52,6 +63,7 @@
 		1F5DED121DEAB98500BC6B1B /* AnyVTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F5DED111DEAB98500BC6B1B /* AnyVTree.swift */; };
 		1F6CF6F91EA33E6C00752203 /* DemoFramework.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1F4A59FC1EA331E700B00F93 /* DemoFramework.framework */; };
 		1F6CF6FA1EA33E6C00752203 /* DemoFramework.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 1F4A59FC1EA331E700B00F93 /* DemoFramework.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		1F6E3F541EACC21E003DFEA2 /* UIView+Ext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F6E3F531EACC21E003DFEA2 /* UIView+Ext.swift */; };
 		1F7AF2921E0D359E0038DED0 /* FuncBoxSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F7AF2911E0D359E0038DED0 /* FuncBoxSpec.swift */; };
 		1F8602E21DFCCF3F0007911E /* FuncBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8602E11DFCCF3F0007911E /* FuncBox.swift */; };
 		1F8602E41DFCD1280007911E /* GestureEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F8602E31DFCD1280007911E /* GestureEvent.swift */; };
@@ -110,6 +122,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		1F2AA9451EAC6DCC000D33E7 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 48FB189E1DD584520027B8B1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1F4C6F461EAB8EA700D641AC;
+			remoteInfo = VTreeDebugger;
+		};
 		1F4A5A011EA331E700B00F93 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 48FB189E1DD584520027B8B1 /* Project object */;
@@ -123,6 +142,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 48FB18A61DD584520027B8B1;
 			remoteInfo = VTree;
+		};
+		1F4C6F4C1EAB8EA700D641AC /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 48FB189E1DD584520027B8B1 /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 1F4C6F461EAB8EA700D641AC;
+			remoteInfo = VTreeDebugger;
 		};
 		1F8ADC811E3E1B4100F4531F /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -170,6 +196,7 @@
 			files = (
 				1FC9034D1E06E694001A70BF /* VTree.framework in Embed Frameworks */,
 				1F4A5A041EA331E700B00F93 /* DemoFramework.framework in Embed Frameworks */,
+				1F4C6F4F1EAB8EA700D641AC /* VTreeDebugger.framework in Embed Frameworks */,
 				1FE74ED21E1F41A800CE2C3E /* Flexbox.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -183,6 +210,7 @@
 			files = (
 				1FC903521E06E69D001A70BF /* VTree.framework in Embed Frameworks */,
 				1F6CF6FA1EA33E6C00752203 /* DemoFramework.framework in Embed Frameworks */,
+				1F2AA9441EAC6DCC000D33E7 /* VTreeDebugger.framework in Embed Frameworks */,
 				1FE74ED31E1F41AC00CE2C3E /* Flexbox.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
@@ -220,11 +248,19 @@
 		1F4A5A0C1EA3323100B00F93 /* Helpers.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Helpers.swift; sourceTree = "<group>"; };
 		1F4A5A0D1EA3323100B00F93 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		1F4A5A0E1EA3323100B00F93 /* Program.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Program.swift; sourceTree = "<group>"; };
+		1F4C6F471EAB8EA700D641AC /* VTreeDebugger.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = VTreeDebugger.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1F4C6F491EAB8EA700D641AC /* VTreeDebugger.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = VTreeDebugger.h; sourceTree = "<group>"; };
+		1F4C6F4A1EAB8EA700D641AC /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		1F4C6F531EAB8ECD00D641AC /* Debugger.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Debugger.swift; sourceTree = "<group>"; };
+		1F4C6F561EAB8F9800D641AC /* Message.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.generated.swift; sourceTree = "<group>"; };
+		1F4C6F571EAB8F9800D641AC /* MessageContext.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = MessageContext.generated.swift; sourceTree = "<group>"; };
+		1F4C6F5F1EABB08E00D641AC /* Slider.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Slider.swift; sourceTree = "<group>"; };
 		1F517BD21E3B926A00A77053 /* Message.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Message.generated.swift; sourceTree = "<group>"; };
 		1F5DECAB1DEAA16200BC6B1B /* KeyCacheSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = KeyCacheSpec.swift; sourceTree = "<group>"; };
 		1F5DECAE1DEAA58A00BC6B1B /* LazyMapSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LazyMapSpec.swift; sourceTree = "<group>"; };
 		1F5DED0F1DEAB3FE00BC6B1B /* UIControl+EnableSendActionsForControlEvents.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIControl+EnableSendActionsForControlEvents.swift"; sourceTree = "<group>"; };
 		1F5DED111DEAB98500BC6B1B /* AnyVTree.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyVTree.swift; sourceTree = "<group>"; };
+		1F6E3F531EACC21E003DFEA2 /* UIView+Ext.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "UIView+Ext.swift"; sourceTree = "<group>"; };
 		1F7AF2911E0D359E0038DED0 /* FuncBoxSpec.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuncBoxSpec.swift; sourceTree = "<group>"; };
 		1F8602E11DFCCF3F0007911E /* FuncBox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FuncBox.swift; sourceTree = "<group>"; };
 		1F8602E31DFCD1280007911E /* GestureEvent.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = GestureEvent.swift; sourceTree = "<group>"; };
@@ -288,7 +324,16 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				1F4C6F5E1EABA15700D641AC /* VTreeDebugger.framework in Frameworks */,
 				1FC567751EA3368F00D7EB1B /* VTree.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F4C6F431EAB8EA700D641AC /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F4C6F5B1EAB95AD00D641AC /* VTree.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -298,6 +343,7 @@
 			files = (
 				1FC903511E06E69D001A70BF /* VTree.framework in Frameworks */,
 				1F6CF6F91EA33E6C00752203 /* DemoFramework.framework in Frameworks */,
+				1F2AA9431EAC6DCC000D33E7 /* VTreeDebugger.framework in Frameworks */,
 				1FE74ED11E1F41A300CE2C3E /* Flexbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -308,6 +354,7 @@
 			files = (
 				1FC9034C1E06E694001A70BF /* VTree.framework in Frameworks */,
 				1F4A5A031EA331E700B00F93 /* DemoFramework.framework in Frameworks */,
+				1F4C6F4E1EAB8EA700D641AC /* VTreeDebugger.framework in Frameworks */,
 				1FE74ED01E1F41A300CE2C3E /* Flexbox.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -346,6 +393,7 @@
 		1F34452C1DF3ADC000D792E3 /* Views (mutable) */ = {
 			isa = PBXGroup;
 			children = (
+				1F6E3F531EACC21E003DFEA2 /* UIView+Ext.swift */,
 				1F06F7591E4B5DBC0020F52B /* RLabel.swift */,
 				1F3C63981DF4C687009F5399 /* RButton.swift */,
 			);
@@ -415,6 +463,27 @@
 				1F4A5A0D1EA3323100B00F93 /* Info.plist */,
 			);
 			path = DemoFramework;
+			sourceTree = "<group>";
+		};
+		1F4C6F481EAB8EA700D641AC /* VTreeDebugger */ = {
+			isa = PBXGroup;
+			children = (
+				1F4C6F551EAB8F9800D641AC /* CodeGenerated */,
+				1F4C6F491EAB8EA700D641AC /* VTreeDebugger.h */,
+				1F4C6F531EAB8ECD00D641AC /* Debugger.swift */,
+				1F4C6F5F1EABB08E00D641AC /* Slider.swift */,
+				1F4C6F4A1EAB8EA700D641AC /* Info.plist */,
+			);
+			path = VTreeDebugger;
+			sourceTree = "<group>";
+		};
+		1F4C6F551EAB8F9800D641AC /* CodeGenerated */ = {
+			isa = PBXGroup;
+			children = (
+				1F4C6F561EAB8F9800D641AC /* Message.generated.swift */,
+				1F4C6F571EAB8F9800D641AC /* MessageContext.generated.swift */,
+			);
+			path = CodeGenerated;
 			sourceTree = "<group>";
 		};
 		1F517BD11E3B926A00A77053 /* CodeGenerated */ = {
@@ -550,6 +619,7 @@
 				1F43AFE41E0BA9E400312DE7 /* Scripts */,
 				1FC903571E06E9C5001A70BF /* Templates */,
 				1FC903271E06E57F001A70BF /* Demo */,
+				1F4C6F481EAB8EA700D641AC /* VTreeDebugger */,
 				48FB18A81DD584520027B8B1 /* Products */,
 				48FB18C81DD5865C0027B8B1 /* Frameworks */,
 			);
@@ -563,6 +633,7 @@
 				1FF41B1E1DD8A48E00443C4A /* SimpleDemo.app */,
 				1FC903381E06E5D6001A70BF /* GestureDemo.app */,
 				1F4A59FC1EA331E700B00F93 /* DemoFramework.framework */,
+				1F4C6F471EAB8EA700D641AC /* VTreeDebugger.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -641,6 +712,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1F4C6F441EAB8EA700D641AC /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F4C6F4B1EAB8EA700D641AC /* VTreeDebugger.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		48FB18A41DD584520027B8B1 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -671,6 +750,25 @@
 			productReference = 1F4A59FC1EA331E700B00F93 /* DemoFramework.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		1F4C6F461EAB8EA700D641AC /* VTreeDebugger */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1F4C6F521EAB8EA700D641AC /* Build configuration list for PBXNativeTarget "VTreeDebugger" */;
+			buildPhases = (
+				1F4C6F5A1EAB8FB800D641AC /* Run Script: VTree generate-message.sh */,
+				1F4C6F421EAB8EA700D641AC /* Sources */,
+				1F4C6F431EAB8EA700D641AC /* Frameworks */,
+				1F4C6F441EAB8EA700D641AC /* Headers */,
+				1F4C6F451EAB8EA700D641AC /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = VTreeDebugger;
+			productName = VTreeDebugger;
+			productReference = 1F4C6F471EAB8EA700D641AC /* VTreeDebugger.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		1FC903371E06E5D6001A70BF /* GestureDemo */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1FC903471E06E5D6001A70BF /* Build configuration list for PBXNativeTarget "GestureDemo" */;
@@ -686,6 +784,7 @@
 			dependencies = (
 				1FC783021EA33DB4000728A7 /* PBXTargetDependency */,
 				1FC903541E06E69D001A70BF /* PBXTargetDependency */,
+				1F2AA9461EAC6DCC000D33E7 /* PBXTargetDependency */,
 			);
 			name = GestureDemo;
 			productName = GestureDemo;
@@ -707,6 +806,7 @@
 			dependencies = (
 				1FC9034F1E06E694001A70BF /* PBXTargetDependency */,
 				1F4A5A021EA331E700B00F93 /* PBXTargetDependency */,
+				1F4C6F4D1EAB8EA700D641AC /* PBXTargetDependency */,
 			);
 			name = SimpleDemo;
 			productName = VTreeDemo;
@@ -766,6 +866,11 @@
 						CreatedOnToolsVersion = 8.3.1;
 						ProvisioningStyle = Manual;
 					};
+					1F4C6F461EAB8EA700D641AC = {
+						CreatedOnToolsVersion = 8.3.2;
+						LastSwiftMigration = 0830;
+						ProvisioningStyle = Manual;
+					};
 					1F8ADC7C1E3E1B3400F4531F = {
 						CreatedOnToolsVersion = 8.2.1;
 						ProvisioningStyle = Automatic;
@@ -804,6 +909,7 @@
 			targets = (
 				48FB18A61DD584520027B8B1 /* VTree */,
 				48FB18AF1DD584520027B8B1 /* VTreeTests */,
+				1F4C6F461EAB8EA700D641AC /* VTreeDebugger */,
 				1F4A59FB1EA331E700B00F93 /* DemoFramework */,
 				1FF41B1D1DD8A48E00443C4A /* SimpleDemo */,
 				1FC903371E06E5D6001A70BF /* GestureDemo */,
@@ -814,6 +920,13 @@
 
 /* Begin PBXResourcesBuildPhase section */
 		1F4A59FA1EA331E700B00F93 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		1F4C6F451EAB8EA700D641AC /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -885,6 +998,20 @@
 			shellPath = /bin/sh;
 			shellScript = "./Scripts/generate-message.sh ./Tests/Fixtures/ ./Tests/Fixtures/CodeGenerated";
 		};
+		1F4C6F5A1EAB8FB800D641AC /* Run Script: VTree generate-message.sh */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputPaths = (
+			);
+			name = "Run Script: VTree generate-message.sh";
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "./Scripts/generate-message.sh ./VTreeDebugger ./VTreeDebugger/CodeGenerated/";
+		};
 		1F517BD41E3B927900A77053 /* Run Script: VTree generate-message.sh */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -955,6 +1082,17 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		1F4C6F421EAB8EA700D641AC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1F4C6F581EAB8F9800D641AC /* Message.generated.swift in Sources */,
+				1F4C6F591EAB8F9800D641AC /* MessageContext.generated.swift in Sources */,
+				1F4C6F601EABB08E00D641AC /* Slider.swift in Sources */,
+				1F4C6F541EAB8ECD00D641AC /* Debugger.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1FC903341E06E5D6001A70BF /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1012,6 +1150,7 @@
 				1F21F6201DD6269800A70C25 /* Patch.swift in Sources */,
 				1FF41B351DD8B12300443C4A /* VTreePrefix.swift in Sources */,
 				1FBFDA9D1DE5604900094059 /* Message.swift in Sources */,
+				1F6E3F541EACC21E003DFEA2 /* UIView+Ext.swift in Sources */,
 				1F21F6211DD6269F00A70C25 /* Apply.swift in Sources */,
 				48034A6C1DD5B07D00B8013D /* VImageView.swift in Sources */,
 			);
@@ -1041,6 +1180,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		1F2AA9461EAC6DCC000D33E7 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1F4C6F461EAB8EA700D641AC /* VTreeDebugger */;
+			targetProxy = 1F2AA9451EAC6DCC000D33E7 /* PBXContainerItemProxy */;
+		};
 		1F4A5A021EA331E700B00F93 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 1F4A59FB1EA331E700B00F93 /* DemoFramework */;
@@ -1050,6 +1194,11 @@
 			isa = PBXTargetDependency;
 			target = 48FB18A61DD584520027B8B1 /* VTree */;
 			targetProxy = 1F4A5A151EA3337B00B00F93 /* PBXContainerItemProxy */;
+		};
+		1F4C6F4D1EAB8EA700D641AC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 1F4C6F461EAB8EA700D641AC /* VTreeDebugger */;
+			targetProxy = 1F4C6F4C1EAB8EA700D641AC /* PBXContainerItemProxy */;
 		};
 		1F8ADC821E3E1B4100F4531F /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1151,6 +1300,51 @@
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
 				SKIP_INSTALL = YES;
+			};
+			name = Release;
+		};
+		1F4C6F501EAB8EA700D641AC /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = VTreeDebugger/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.inamiy.VTreeDebugger;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 3.0;
+			};
+			name = Debug;
+		};
+		1F4C6F511EAB8EA700D641AC /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_ENABLE_MODULES = YES;
+				CODE_SIGN_IDENTITY = "";
+				DEFINES_MODULE = YES;
+				DEVELOPMENT_TEAM = "";
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				INFOPLIST_FILE = VTreeDebugger/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.inamiy.VTreeDebugger;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
+				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -1406,6 +1600,15 @@
 			buildConfigurations = (
 				1F4A5A051EA331E700B00F93 /* Debug */,
 				1F4A5A061EA331E700B00F93 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		1F4C6F521EAB8EA700D641AC /* Build configuration list for PBXNativeTarget "VTreeDebugger" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1F4C6F501EAB8EA700D641AC /* Debug */,
+				1F4C6F511EAB8EA700D641AC /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/VTreeDebugger/CodeGenerated/Message.generated.swift
+++ b/VTreeDebugger/CodeGenerated/Message.generated.swift
@@ -1,0 +1,50 @@
+// Generated using Sourcery 0.5.3 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+import VTree
+
+extension DebugMsg: Message
+{
+    public init?(rawMessage: RawMessage)
+    {
+        switch rawMessage.funcName {
+
+            // .original(Msg)
+            case "original":
+                let arguments = rawMessage.arguments
+                if let context = Msg(rawArguments: arguments) {
+                    self = .original(context)
+                }
+                else {
+                    return nil
+                }
+
+            // .slider(PanGestureContext)
+            case "slider":
+                let arguments = rawMessage.arguments
+                if let context = PanGestureContext(rawArguments: arguments) {
+                    self = .slider(context)
+                }
+                else {
+                    return nil
+                }
+
+            default:
+                return nil
+        }
+    }
+
+    public var rawMessage: RawMessage
+    {
+        switch self {
+
+            case let .original(context):
+                return RawMessage(funcName: "original", arguments: context.rawArguments)
+
+            case let .slider(context):
+                return RawMessage(funcName: "slider", arguments: context.rawArguments)
+
+        }
+    }
+}
+

--- a/VTreeDebugger/CodeGenerated/MessageContext.generated.swift
+++ b/VTreeDebugger/CodeGenerated/MessageContext.generated.swift
@@ -1,0 +1,11 @@
+// Generated using Sourcery 0.5.3 — https://github.com/krzysztofzablocki/Sourcery
+// DO NOT EDIT
+
+#if os(iOS) || os(tvOS)
+import UIKit
+#elseif os(macOS)
+import AppKit
+#endif
+import VTree
+
+

--- a/VTreeDebugger/Debugger.swift
+++ b/VTreeDebugger/Debugger.swift
@@ -1,0 +1,122 @@
+import Foundation
+import VTree
+import Flexbox
+
+/// A protocol that `VTreeDebugger` requires `rootSize` for layouting additional UI components.
+public protocol DebuggableModel: CustomStringConvertible
+{
+    var rootSize: CGSize { get }
+}
+
+/// Wrapper of `Model` with storing `histories` for time-travelling.
+public struct DebugModel<Model: DebuggableModel, Msg: Message>
+{
+    fileprivate let original: Model
+    fileprivate let histories: [DebugHistory<Model, Msg>]
+
+    fileprivate let slideRatio: Double
+    fileprivate let historyIndex: Int?
+
+    public init(_ model: Model)
+    {
+        self.original = model
+        self.histories = [DebugHistory<Model, Msg>(model: model)]
+        self.slideRatio = 1
+        self.historyIndex = nil
+    }
+
+    fileprivate init(_ model: Model, histories: [DebugHistory<Model, Msg>], slideRatio: Double = 1, historyIndex: Int? = nil)
+    {
+        self.original = model
+        self.histories = histories
+        self.slideRatio = slideRatio
+        self.historyIndex = historyIndex
+    }
+}
+
+/// Wrapper of `Msg`.
+public enum DebugMsg<Msg: Message>: AutoMessage
+{
+    // sourcery: MessageContext
+    case original(Msg)
+
+    case slider(PanGestureContext)
+}
+
+/// Wrapper of `update`.
+public func debugUpdate<Model: DebuggableModel, Msg: Message>(_ update: @escaping (Model, Msg) -> Model?) -> (DebugModel<Model, Msg>, DebugMsg<Msg>) -> DebugModel<Model, Msg>?
+{
+    return { debugModel, debugMsg in
+        let histories = debugModel.histories
+
+        switch debugMsg {
+        case let .original(msg):
+            return update(debugModel.original, msg)
+                .map { DebugModel<Model, Msg>($0, histories: histories + [DebugHistory(msg: msg, model: $0)]) }
+        case let .slider(panContext):
+
+            let slideRatio = max(0, min(1, panContext.location.x / debugModel.original.rootSize.width))
+
+            let index = Int(round(CGFloat(histories.count - 1) * slideRatio))
+            let history = histories[index]
+
+            return DebugModel(
+                history.model,
+                histories: histories,
+                slideRatio: Double(slideRatio),
+                historyIndex: index
+            )
+        }
+    }
+}
+
+/// Wrapper of `view`.
+public func debugView<Model: DebuggableModel, Msg: Message, T: VTree>(_ view: @escaping (Model) -> T) -> (DebugModel<Model, Msg>) -> AnyVTree<DebugMsg<Msg>>
+    where T.MsgType == Msg
+{
+    return { debugModel in
+        let model = debugModel.original
+        let originalTree = (*view(model)).map(DebugMsg.original)
+
+        return *VView(
+            frame: CGRect(origin: .zero, size: model.rootSize),
+            children: {
+                let text = debugModel.historyIndex
+                    .map { index -> String in
+                        let history = debugModel.histories[index]
+                        let msgName = history.msg?.rawMessage.funcName ?? "Initial"
+                        return "[\(index)] \(msgName), \(history.model.description)"
+                    }
+
+                return [
+                    originalTree,
+                    debugSlider(
+                        text: text,
+                        ratio: CGFloat(debugModel.slideRatio),
+                        rootSize: model.rootSize
+                    )
+                ]
+            }()
+        )
+    }
+}
+
+// MARK: Private
+
+fileprivate struct DebugHistory<Model: DebuggableModel, Msg: Message>
+{
+    fileprivate let msg: Msg?
+    fileprivate let model: Model
+
+    fileprivate init(msg: Msg, model: Model)
+    {
+        self.msg = msg
+        self.model = model
+    }
+
+    fileprivate init(model: Model)
+    {
+        self.msg = nil
+        self.model = model
+    }
+}

--- a/VTreeDebugger/Info.plist
+++ b/VTreeDebugger/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/VTreeDebugger/Slider.swift
+++ b/VTreeDebugger/Slider.swift
@@ -1,0 +1,110 @@
+import Foundation
+import VTree
+import Flexbox
+
+internal func debugSlider<Msg: Message>(text: String?, ratio: CGFloat, rootSize: CGSize) -> AnyVTree<DebugMsg<Msg>>
+{
+    let sliderHeight: CGFloat = 100
+    let labelHeight: CGFloat = 30
+
+    func hairline<Msg: Message>() -> AnyVTree<DebugMsg<Msg>>
+    {
+        return *VView(
+            backgroundColor: #colorLiteral(red: 0.2549019754, green: 0.2745098174, blue: 0.3019607961, alpha: 1),
+            flexbox: Flexbox.Node(
+                size: CGSize(width: rootSize.width - 40, height: 1),
+                maxSize: CGSize(width: rootSize.width - 40, height: sliderHeight),
+                flexGrow: 1
+            )
+        )
+    }
+
+    func slideHandle<Msg: Message>(ratio: CGFloat) -> AnyVTree<DebugMsg<Msg>>
+    {
+        let handleWidth: CGFloat = 40
+
+        func labelWrapper<Msg: Message>(text: String?, ratio: CGFloat) -> AnyVTree<DebugMsg<Msg>>
+        {
+            let labelWrapperWidth: CGFloat = rootSize.width
+
+            func label<Msg: Message>(text: String?, ratio: CGFloat) -> AnyVTree<DebugMsg<Msg>>
+            {
+                return *VLabel<DebugMsg<Msg>>(
+                    backgroundColor: #colorLiteral(red: 0, green: 0, blue: 0, alpha: 1).withAlphaComponent(0.5),
+                    isHidden: text == nil,
+                    text: text,
+                    textColor: .white,
+                    textAlignment: .center,
+                    font: .systemFont(ofSize: 24),
+                    flexbox: Flexbox.Node(
+                        padding: Edges(uniform: 4)
+                    )
+                )
+            }
+
+            // labelWrapper
+            return *VView<DebugMsg<Msg>>(
+                isHidden: text == nil,
+                flexbox: Flexbox.Node(
+                    size: CGSize(width: labelWrapperWidth, height: labelHeight),
+                    flexDirection: .columnReverse,
+                    alignItems: .center,
+                    positionType: .absolute,
+                    position: Edges(
+                        left: -labelWrapperWidth/2 + handleWidth/2,
+                        top: -40
+                    )
+                ),
+                children: [
+                    label(text: text, ratio: ratio)
+                ]
+            )
+        }
+
+        // slideHandle
+        return *VView(
+            backgroundColor: #colorLiteral(red: 0.2392156869, green: 0.6745098233, blue: 0.9686274529, alpha: 1),
+            cornerRadius: handleWidth/2,
+            flexbox: Flexbox.Node(
+                size: CGSize(width: handleWidth, height: handleWidth),
+                positionType: .absolute,
+                position: Edges(
+                    left: max(0, min(rootSize.width - handleWidth, rootSize.width * ratio - handleWidth/2)),
+                    top: (sliderHeight - handleWidth)/2
+                )
+            ),
+            children: [
+                *labelWrapper(text: text, ratio: 0)
+            ]
+        )
+    }
+
+    func slider() -> AnyVTree<DebugMsg<Msg>>
+    {
+        return *VView(
+            flexbox: Flexbox.Node(
+                size: CGSize(width: rootSize.width, height: sliderHeight),
+                flexDirection: .row,
+                justifyContent: .center,
+                alignItems: .center
+            ),
+            children: [
+                hairline(),
+                slideHandle(ratio: ratio)
+            ]
+        )
+    }
+
+    // debugSlider
+    return *VView(
+        frame: CGRect(x: 0, y: rootSize.height - sliderHeight, width: rootSize.width, height: sliderHeight),
+        flexbox: Flexbox.Node(
+            flexDirection: .column,
+            alignItems: .center
+        ),
+        gestures: [.pan(^DebugMsg<Msg>.slider)],
+        children: [
+            slider(),
+        ]
+    )
+}

--- a/VTreeDebugger/VTreeDebugger.h
+++ b/VTreeDebugger/VTreeDebugger.h
@@ -1,0 +1,11 @@
+#import <UIKit/UIKit.h>
+
+//! Project version number for VTreeDebugger.
+FOUNDATION_EXPORT double VTreeDebuggerVersionNumber;
+
+//! Project version string for VTreeDebugger.
+FOUNDATION_EXPORT const unsigned char VTreeDebuggerVersionString[];
+
+// In this header, you should import all the public headers of your framework using statements like #import <VTreeDebugger/PublicHeader.h>
+
+

--- a/VTreePlayground.playground/Pages/Gesture.xcplaygroundpage/Contents.swift
+++ b/VTreePlayground.playground/Pages/Gesture.xcplaygroundpage/Contents.swift
@@ -42,11 +42,11 @@ func update(_ model: Model, _ msg: Msg) -> Model
 {
     print(msg)  // Warning: impure logging
 
-    let argsString = msg.rawValue.arguments.map { "\($0)" }.joined(separator: "\n")
+    let argsString = msg.rawMessage.arguments.map { "\($0)" }.joined(separator: "\n")
     let cursor = Model.Cursor(msg: msg)
 
     return Model(
-        message: "\(msg.rawValue.funcName)\n\(argsString)",
+        message: "\(msg.rawMessage.funcName)\n\(argsString)",
         cursor: cursor
     )
 }

--- a/VTreePlayground.playground/Pages/Gesture.xcplaygroundpage/Sources/Message.generated.swift
+++ b/VTreePlayground.playground/Pages/Gesture.xcplaygroundpage/Sources/Message.generated.swift
@@ -5,9 +5,9 @@ import VTree
 
 extension Msg: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             case "increment":
                 self = .increment
@@ -17,8 +17,8 @@ extension Msg: Message
 
             // .tap(GestureContext)
             case "tap":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .tap(context)
                 }
                 else {
@@ -27,8 +27,8 @@ extension Msg: Message
 
             // .pan(PanGestureContext)
             case "pan":
-                let arguments = rawValue.arguments
-                if let context = PanGestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = PanGestureContext(rawArguments: arguments) {
                     self = .pan(context)
                 }
                 else {
@@ -37,8 +37,8 @@ extension Msg: Message
 
             // .longPress(GestureContext)
             case "longPress":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .longPress(context)
                 }
                 else {
@@ -47,8 +47,8 @@ extension Msg: Message
 
             // .swipe(GestureContext)
             case "swipe":
-                let arguments = rawValue.arguments
-                if let context = GestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = GestureContext(rawArguments: arguments) {
                     self = .swipe(context)
                 }
                 else {
@@ -57,8 +57,8 @@ extension Msg: Message
 
             // .pinch(PinchGestureContext)
             case "pinch":
-                let arguments = rawValue.arguments
-                if let context = PinchGestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = PinchGestureContext(rawArguments: arguments) {
                     self = .pinch(context)
                 }
                 else {
@@ -67,8 +67,8 @@ extension Msg: Message
 
             // .rotation(RotationGestureContext)
             case "rotation":
-                let arguments = rawValue.arguments
-                if let context = RotationGestureContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = RotationGestureContext(rawArguments: arguments) {
                     self = .rotation(context)
                 }
                 else {
@@ -77,8 +77,8 @@ extension Msg: Message
 
             // .dummy(DummyContext)
             case "dummy":
-                let arguments = rawValue.arguments
-                if let context = DummyContext(rawValue: arguments) {
+                let arguments = rawMessage.arguments
+                if let context = DummyContext(rawArguments: arguments) {
                     self = .dummy(context)
                 }
                 else {
@@ -90,7 +90,7 @@ extension Msg: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 
@@ -101,25 +101,25 @@ extension Msg: Message
                 return RawMessage(funcName: "decrement", arguments: [])
 
             case let .tap(context):
-                return RawMessage(funcName: "tap", arguments: context.rawValue)
+                return RawMessage(funcName: "tap", arguments: context.rawArguments)
 
             case let .pan(context):
-                return RawMessage(funcName: "pan", arguments: context.rawValue)
+                return RawMessage(funcName: "pan", arguments: context.rawArguments)
 
             case let .longPress(context):
-                return RawMessage(funcName: "longPress", arguments: context.rawValue)
+                return RawMessage(funcName: "longPress", arguments: context.rawArguments)
 
             case let .swipe(context):
-                return RawMessage(funcName: "swipe", arguments: context.rawValue)
+                return RawMessage(funcName: "swipe", arguments: context.rawArguments)
 
             case let .pinch(context):
-                return RawMessage(funcName: "pinch", arguments: context.rawValue)
+                return RawMessage(funcName: "pinch", arguments: context.rawArguments)
 
             case let .rotation(context):
-                return RawMessage(funcName: "rotation", arguments: context.rawValue)
+                return RawMessage(funcName: "rotation", arguments: context.rawArguments)
 
             case let .dummy(context):
-                return RawMessage(funcName: "dummy", arguments: context.rawValue)
+                return RawMessage(funcName: "dummy", arguments: context.rawArguments)
 
         }
     }

--- a/VTreePlayground.playground/Pages/Gesture.xcplaygroundpage/Sources/MessageContext.generated.swift
+++ b/VTreePlayground.playground/Pages/Gesture.xcplaygroundpage/Sources/MessageContext.generated.swift
@@ -11,14 +11,14 @@ import VTree
 
 extension DummyContext: MessageContext
 {
-    public init?(rawValue: [Any])
+    public init?(rawArguments: [Any])
     {
-        guard rawValue.count == 0 else { return nil }
+        guard rawArguments.count == 0 else { return nil }
 
         self = DummyContext()
     }
 
-    public var rawValue: [Any]
+    public var rawArguments: [Any]
     {
         return []
     }

--- a/VTreePlayground.playground/Pages/Simple Counter (Flexbox).xcplaygroundpage/Sources/Message.generated.swift
+++ b/VTreePlayground.playground/Pages/Simple Counter (Flexbox).xcplaygroundpage/Sources/Message.generated.swift
@@ -5,9 +5,9 @@ import VTree
 
 extension Msg: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             case "increment":
                 self = .increment
@@ -20,7 +20,7 @@ extension Msg: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 

--- a/VTreePlayground.playground/Pages/Simple Counter.xcplaygroundpage/Sources/Message.generated.swift
+++ b/VTreePlayground.playground/Pages/Simple Counter.xcplaygroundpage/Sources/Message.generated.swift
@@ -5,9 +5,9 @@ import VTree
 
 extension Msg: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             case "increment":
                 self = .increment
@@ -20,7 +20,7 @@ extension Msg: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 

--- a/VTreePlayground.playground/Pages/Test.xcplaygroundpage/Contents.swift
+++ b/VTreePlayground.playground/Pages/Test.xcplaygroundpage/Contents.swift
@@ -3,13 +3,19 @@ import PlaygroundSupport
 import VTree
 import Flexbox
 import DemoFramework
+import VTreeDebugger
 
-struct Model
+struct Model: DebuggableModel
 {
     static let initial = Model(count: 0)
 
     let rootSize = CGSize(width: 320, height: 800)
     let count: Int
+
+    var description: String
+    {
+        return "\(count)"
+    }
 }
 
 func update(_ model: Model, _ msg: Msg) -> Model
@@ -58,7 +64,8 @@ func view(model: Model) -> VView<Msg>
             textAlignment: .center,
             font: .systemFont(ofSize: 48),
             flexbox: Flexbox.Node(
-                maxSize: CGSize(width: rootWidth - space*2, height: CGFloat.nan)
+                maxSize: CGSize(width: rootWidth - space*2, height: CGFloat.nan),
+                positionType: .absolute
             )
         )
     }
@@ -184,6 +191,6 @@ func view(model: Model) -> VView<Msg>
     ])
 }
 
-let program = Program(model: .initial, update: update, view: view, debug: true)
+let program = debugProgram(debug: true, model: .initial, update: update, view: view)
 
 PlaygroundPage.current.liveView = program.rootView

--- a/VTreePlayground.playground/Pages/Test.xcplaygroundpage/Sources/Message.generated.swift
+++ b/VTreePlayground.playground/Pages/Test.xcplaygroundpage/Sources/Message.generated.swift
@@ -5,9 +5,9 @@ import VTree
 
 extension Msg: Message
 {
-    public init?(rawValue: RawMessage)
+    public init?(rawMessage: RawMessage)
     {
-        switch rawValue.funcName {
+        switch rawMessage.funcName {
 
             case "increment":
                 self = .increment
@@ -20,7 +20,7 @@ extension Msg: Message
         }
     }
 
-    public var rawValue: RawMessage
+    public var rawMessage: RawMessage
     {
         switch self {
 


### PR DESCRIPTION
This PR adds "time-travelling debugger" example and fixes some major bugs that weren't aware until the composition of this debugger UI.

- Add `VTreeDebugger` (time-travelling debugger)
- Fix Flexbox-diffing algorithm (Bug fix)
- Change `Message` & `MessageContext` protocols
    - Protcols does not conform to `RawRepresentable` anymore
    - `Message` will now conform to `MessageContext`
- Remove `ViewConfig`, replacing back to `msgMapper`
- Add `cornerRadius` support

### Screencast (Time-travel)

![](https://cloud.githubusercontent.com/assets/138476/25313934/4075c752-2874-11e7-8924-7c1579c7fe7d.gif)
